### PR TITLE
fix: Made pdf upload mandatory for chat-w-pdf agent

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import NavWrapper from "@/clientWrapper/NavWrapper";
 import PageTransition from "@/clientWrapper/TransitionWrapper";
 import { ThemeProvider } from "next-themes";
@@ -18,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${GeistSans.className} antialiased`}>
+      <body className={`${GeistMono.className} antialiased`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -52,6 +52,7 @@ import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { useChatStore } from "@/stores/useChatStore";
 import { usePdfDataStore } from "@/stores/usePdfDataStore";
+import EmptyPDFstate from "./EmptyPDFstate";
 
 async function convertFilesToDataURLs(
   files: FileList
@@ -84,12 +85,34 @@ async function convertFilesToDataURLs(
 }
 
 export default function ChatInterface() {
+  const [loading, setLoading] = useState(false);
+  const {
+    pdfUploaded,
+    setPdfUploaded,
+    pdfDataUrl,
+    pdfFile,
+    setPdfDataUrl,
+    pdfName,
+    setPdfFile,
+    setPdfName,
+  } = usePdfDataStore();
+
   const { messages, status, sendMessage, regenerate, stop } = useChat({
     transport: new DefaultChatTransport({
       api: "/api/chat",
     }),
   });
 
+  const handleChange = () => {
+    setLoading(true);
+    try {
+      setPdfUploaded(!pdfUploaded);
+    } catch (error) {
+      console.log("Some error occured at handleChange pdfUploaded state");
+    } finally {
+      setLoading(false);
+    }
+  };
   const { addMessage, setMessages, removeExpiredChat } = useChatStore();
 
   useEffect(() => {
@@ -157,8 +180,6 @@ export default function ChatInterface() {
     },
   ];
 
-  const { pdfFile, pdfName, pdfDataUrl } = usePdfDataStore();
-
   useEffect(() => {
     if (pdfFile && pdfDataUrl) {
       setAttachments([
@@ -169,8 +190,13 @@ export default function ChatInterface() {
           file: pdfFile,
         },
       ]);
+      setPdfUploaded(true);
     }
   }, [pdfFile, pdfName, pdfDataUrl]);
+
+  if (!pdfUploaded) {
+    return <EmptyPDFstate handleChange={handleChange} />;
+  }
 
   return (
     <div className="bg-background border border-accent max-w-4xl mt-6 w-full px-4 py-4 rounded-2xl shadow-lg">


### PR DESCRIPTION
fixes issue #3 

previously User was able to start a chat without uploading a pdf.

now added pdfUploaded state from global zustand store that conditionally renders the empty component that asks user to upload a pdf to start chatting with it, exactly what we need from a chat with pdf agent.

<img width="1920" height="1080" alt="Screenshot from 2025-12-11 22-36-40" src="https://github.com/user-attachments/assets/4a04a4d4-480d-4186-ac50-458c13395b7c" />
<img width="1920" height="1080" alt="Screenshot from 2025-12-11 22-36-53" src="https://github.com/user-attachments/assets/8b234e06-7136-499c-b2f3-29b20f8ced6b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced PDF upload and attachment functionality to the chat interface. Users can now attach PDF files to messages with automatic integration.

* **Style**
  * Updated the application's default font styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->