### PR TITLE
fix: Removes attached pdfs after the inital message

### DIFF
--- a/src/components/EmptyPDFstate.tsx
+++ b/src/components/EmptyPDFstate.tsx
@@ -51,27 +51,31 @@ export default function EmptyPDFstate({
   };
 
   return (
-    <Empty>
-      <EmptyHeader>
-        <EmptyMedia variant="icon">
-          <Upload />
-        </EmptyMedia>
-        <EmptyTitle>No Pdf uploaded</EmptyTitle>
-        <EmptyDescription>Get started by uploading your pdf.</EmptyDescription>
-      </EmptyHeader>
-      <EmptyContent>
-        <input
-          type="file"
-          ref={fileInputRef}
-          className="hidden"
-          accept="application/pdf"
-          onChange={handleFileChange}
-        />
-        <Button onClick={handleUploadClick}>
-          <Upload />
-          Upload pdf
-        </Button>
-      </EmptyContent>
-    </Empty>
+    <div className="bg-background border border-accent max-w-4xl mt-6 w-full px-4 py-4 rounded-2xl shadow-lg">
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Upload />
+          </EmptyMedia>
+          <EmptyTitle>No Pdf uploaded</EmptyTitle>
+          <EmptyDescription>
+            Get started by uploading your pdf.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <input
+            type="file"
+            ref={fileInputRef}
+            className="hidden"
+            accept="application/pdf"
+            onChange={handleFileChange}
+          />
+          <Button onClick={handleUploadClick}>
+            <Upload />
+            Upload pdf
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </div>
   );
 }


### PR DESCRIPTION
fixes issue #4

fixes and enhancements:
- removes attached pdf after the first chat by resetting  setAttachments([ ])
- added copy ai response functionality with proper types from ai-sdk

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2e6e75b5-f96e-4f02-a727-b460b633a81c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy-to-clipboard functionality for assistant messages with "Copied!" visual feedback
  * Loading indicator during response generation

* **Bug Fixes**
  * Attachments now clear automatically when submitting chat

* **Style**
  * Enhanced UI spacing and visual styling for improved consistency
  * Improved empty state layout presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->