### PR TITLE
feat: Added RSC for DailyLog screen

### DIFF
--- a/src/app/(dashboard)/tools/dailyLogs/page.tsx
+++ b/src/app/(dashboard)/tools/dailyLogs/page.tsx
@@ -1,9 +1,9 @@
-import DailyLogScreen from "@/components/DailyLogs";
+import DailyLogScreen from "@/components/dailyLog/DailyLogs";
 import React from "react";
 
 export default function Page() {
   return (
-    <div className="">
+    <div>
       <DailyLogScreen />
     </div>
   );

--- a/src/app/actions/createDailyLog.ts
+++ b/src/app/actions/createDailyLog.ts
@@ -7,6 +7,7 @@ import {
   DailyLog,
   dailyLogSchema,
 } from "@/zodSchemas/dailyLog.schema";
+import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 
 export async function createDailyLog(payload: DailyLog) {
@@ -37,6 +38,8 @@ export async function createDailyLog(payload: DailyLog) {
         },
       },
     });
+    revalidatePath("/tools/dailyLogs");
+    return { success: true };
   } catch (error) {
     console.error("createDailyLog error:", error);
     throw new Error("DATABASE_ERROR");

--- a/src/app/actions/getDailyLog.ts
+++ b/src/app/actions/getDailyLog.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+
+export async function getTodayLog(userId: string, date: Date) {
+  if (!userId || !date) {
+    throw new Error("PAYLOAD_IS_MISSING");
+  }
+  try {
+    const todayLog = await prisma.dailyLogs.findUnique({
+      where: {
+        userId_date: {
+          userId,
+          date,
+        },
+      },
+      include: {
+        categories: true,
+      },
+    });
+
+    if (!todayLog) {
+      return null;
+    }
+
+    return todayLog;
+  } catch (error) {
+    console.error("getDailyLog error:", error);
+    throw new Error("DATABASE_ERROR");
+  }
+}

--- a/src/components/dailyLog/DailyLogForm.tsx
+++ b/src/components/dailyLog/DailyLogForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Card,
   CardContent,
@@ -13,19 +13,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import {
-  CATEGORIES,
-  Category,
-  DailyLog,
-  dailyLogSchema,
-} from "@/zodSchemas/dailyLog.schema";
+import { CATEGORIES, Category, DailyLog } from "@/zodSchemas/dailyLog.schema";
 import { createDailyLog } from "@/app/actions/createDailyLog";
 import { toast } from "sonner";
-import { Spinner } from "./ui/spinner";
+import { Spinner } from "../ui/spinner";
 
-export default function DailyLogScreen() {
+export default function DailyLogForm({ currentDate }: { currentDate: Date }) {
   const [logContent, setLogContent] = useState<DailyLog["log"]>("");
   const [selectedCategories, setSelectedCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(false);
@@ -38,25 +31,21 @@ export default function DailyLogScreen() {
     );
   };
 
-  dayjs.extend(utc);
-  dayjs.extend(timezone);
-
-  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  const currentDate = dayjs().tz(userTimezone).startOf("day").toDate();
   const formattedDate = dayjs(currentDate).format("DD MMM YYYY");
 
   const handleSubmitLog = async () => {
     try {
       setLoading(true);
-      await createDailyLog({
+      const res = await createDailyLog({
         log: logContent,
         categories: selectedCategories,
         date: currentDate,
       });
-      toast.success("LOG ADDED", {
-        description: "Daily log successfully added",
-      });
+      if (res.success) {
+        toast.success("LOG ADDED", {
+          description: "Daily log successfully added",
+        });
+      }
     } catch (error) {
       if (error instanceof Error) {
         switch (error.message) {

--- a/src/components/dailyLog/DailyLogs.tsx
+++ b/src/components/dailyLog/DailyLogs.tsx
@@ -1,0 +1,34 @@
+import { getTodayLog } from "@/app/actions/getDailyLog";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import React from "react";
+
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import TodayLog from "./TodayLog";
+import DailyLogForm from "./DailyLogForm";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export default async function DailyLogScreen() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("UNAUTHORIZED");
+  }
+
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const todayDate = dayjs().tz(userTimezone).startOf("day").toDate();
+
+  const todayLog = await getTodayLog(session.user?.id, todayDate);
+
+  return todayLog ? (
+    <TodayLog log={todayLog.log} today={todayLog.date} />
+  ) : (
+    <DailyLogForm currentDate={todayDate} />
+  );
+}

--- a/src/components/dailyLog/TodayLog.tsx
+++ b/src/components/dailyLog/TodayLog.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Badge } from "../ui/badge";
+import dayjs from "dayjs";
+
+export default function TodayLog({ log, today }: { log: string; today: Date }) {
+  return (
+    <div className="min-h-screen w-full justify-center items-center flex flex-col space-y-4">
+      <div className="space-y-2">
+        <Badge>{dayjs(today).format("DD MMM YYYY")}</Badge>
+        <p className="text-xl font-bold italic tracking-[-1.2px]">{log}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### stuff added
- made dailylog screen rsc
- as one log/day, therefore fetched this 👇:
- todayLog if present then showing `<TodayLog log={todayLog.log} today={todayLog.date} />`
- else showing the form component to add today's log `<DailyLogForm currentDate={todayDate} />`
- using `revalidatePath` to invalidate the cache and re-render the rsc `<DailyLogScreen/>`
---
### current flow
- user submits form
- server action writes to db
- server tells nextjs to “invalidate this page”
- rsc re-runs automatically
- form component disappears, log component appears
- form component path = `/src/components/dailyLog/DailyLogForm.tsx`
- log component path = `/src/components/dailyLog/TodayLog.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily log entries are now retrievable and displayable to users
  * Enhanced form validation with improved success confirmation

* **Refactor**
  * Reorganized component structure for daily logs management
  * Optimized caching mechanism for content updates and performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->